### PR TITLE
[Add] apiConfig, apiMapper

### DIFF
--- a/src/api/apiConfig.js
+++ b/src/api/apiConfig.js
@@ -1,0 +1,72 @@
+import Axios from 'axios';
+
+export const HttpMethod = {
+  GET: 'get',
+  POST: 'post',
+  PUT: 'put',
+  PATCH: 'patch',
+  // DELETE: 'delete',
+};
+
+export default class ApiConfig {
+  static request({data, query, path, method, url, role}) {
+    try {
+      if (isEmpty(method) || isEmpty(url)) {
+        console.log('HTTP Method 와 URL 을 확인해주세요.');
+        return;
+      }
+
+      if (path) {
+        for (const [key, value] of Object.entries(path)) {
+          url = url.replace(`:${key}`, value);
+        }
+      }
+
+      if (!isEmpty(query)) {
+        url +=
+          '?' +
+          Object.keys(query)
+            .map(key => key + '=' + query[key])
+            .join('&');
+      }
+
+      const headers = {
+        accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Access-Token':
+        //   async스토리지에 저장필요
+      };
+      const noJwtHeaders = {
+        'Content-Type': 'application/json',
+      };
+      // console.log(method);
+      switch (method) {
+        case HttpMethod.GET:
+          return Axios.get(url, {headers: headers});
+        case HttpMethod.POST:
+          return Axios.post(url, data, {headers: headers});
+        case HttpMethod.NO_JWT_POST:
+          return Axios.post(url, data, {headers: noJwtHeaders});
+        case HttpMethod.PATCH:
+          return Axios.patch(url, data, {headers: headers});
+        case HttpMethod.PUT:
+          return Axios.put(url, data, {headers: headers});
+        // case HttpMethod.DELETE:
+        //   return Axios.delete(url, data, {headers: headers})
+        default:
+          break;
+      }
+    } catch (error) {
+      console.log('ApiConfig Error : ', error.message);
+    }
+  }
+}
+
+const isEmpty = function (value) {
+  return (
+    value === '' ||
+    value === null ||
+    value === undefined ||
+    (typeof value === 'object' && !Object.keys(value).length)
+  );
+};

--- a/src/api/apiMapper.js
+++ b/src/api/apiMapper.js
@@ -1,0 +1,17 @@
+//예시
+const API = process.env.REACT_APP_API;
+
+export const EndPoint = {
+  common: {
+    get: {
+      DOMAIN_V1_AUTO_LOGIN: `${API}/domain/jwt/check/:isManual`,
+      DOMAIN_V1_DISTINCT_NERDS: `${API}/domain/v1/neordinary/distinct/nerds`,
+      DOMAIN_V1_DISTINCT_KEEPERS: `${API}/domain/v1/neordinary/distinct/keepers`,
+    },
+    post: {
+      DOMAIN_V1_LOGIN: `${API}/domain/login`,
+      DOMAIN_V1_REGISTER: `${API}/domain/register`,
+      DOMAIN_V1_UPDATE_NERD: `${API}/domain/v1/neordinary/nerds/:nerdId`,
+    },
+  },
+};


### PR DESCRIPTION
사용예시
```
 const { data: response } = await ApiConfig.request({
        method: HttpMethod.POST,
        url: EndPoint.POST_WEB_PROPOSALS_MIDDLE_SAVE,
        data: {
          proposalId: initialBiddingData.proposalId,
          serviceKeywordIds: postKeyword,
          conceptAndIntroduce: serviceConcept,
        },
        query: { step: 'serviceKeyword' },
      });
```